### PR TITLE
Enable scroll on the list of tests

### DIFF
--- a/apps/codelab/src/app/components/exercise/exercise.component.css
+++ b/apps/codelab/src/app/components/exercise/exercise.component.css
@@ -10,4 +10,5 @@
 .tests {
   padding: 0.5vw;
   box-sizing: border-box;
+  overflow-y: auto;
 }


### PR DESCRIPTION
The list of tests can now be scrolled when the list is too long

Fixes #1067 

### Proof :
![image](https://user-images.githubusercontent.com/17952318/66216554-f97a5300-e6c5-11e9-8f6b-ec253a5f82ab.png)
