### PR TITLE
Fix overlapping elements

### DIFF
--- a/apps/codelab/src/app/components/exercise-playground/codelab-exercise-playground.component.css
+++ b/apps/codelab/src/app/components/exercise-playground/codelab-exercise-playground.component.css
@@ -1,0 +1,4 @@
+:host {
+  display: flex;
+  flex-direction: column;
+}

--- a/apps/codelab/src/app/components/exercise-playground/codelab-exercise-playground.component.ts
+++ b/apps/codelab/src/app/components/exercise-playground/codelab-exercise-playground.component.ts
@@ -4,7 +4,8 @@ import { PreviewWindowType } from '@codelab/browser/src/lib/preview-window/previ
 
 @Component({
   selector: 'codelab-exercise-playground',
-  templateUrl: 'codelab-exercise-playground.component.html'
+  templateUrl: 'codelab-exercise-playground.component.html',
+  styleUrls: ['codelab-exercise-playground.component.css'],
 })
 export class CodelabExercisePlaygroundComponent extends CodelabExerciseComponent {
   @Input() allowSwitchingFiles = false;


### PR DESCRIPTION
An element was overlapping over CodelabExercisePlaygroundComponent
because it didn't have styles for its host element.

This closes #1105 