### PR TITLE
Fix autofold imports issue#1208

### DIFF
--- a/apps/codelab/src/app/codelabs/angular/component-tree/component-tree.component.html
+++ b/apps/codelab/src/app/codelabs/angular/component-tree/component-tree.component.html
@@ -92,6 +92,7 @@
       <div column-5>
         <code-demo-file-path path="box.component.ts"></code-demo-file-path>
         <code-demo-editor
+          autoFolding
           [fontSize]="15"
           [(ngModel)]="code.circleAndBox.other.boxNoParams"
           [codeDemoHighlight]="code.parentComponentSkeleton.match"
@@ -100,6 +101,7 @@
       <div column-5>
         <code-demo-file-path path="circle.component.ts"></code-demo-file-path>
         <code-demo-editor
+          autoFolding
           [fontSize]="15"
           [(ngModel)]="code.circleAndBox.files[0].code"
           [codeDemoHighlight]="code.parentComponentSkeleton.match"
@@ -205,6 +207,7 @@
         <div column-5>
           <code-demo-file-path path="box.component.ts"></code-demo-file-path>
           <code-demo-editor
+            autoFolding
             [fontSize]="15"
             [(ngModel)]="code.circleAndBox.files[1].code"
             [codeDemoHighlight]="code.parentComponentSkeleton.match"
@@ -213,6 +216,7 @@
         <div column-5>
           <code-demo-file-path path="circle.component.ts"></code-demo-file-path>
           <code-demo-editor
+            autoFolding
             [fontSize]="15"
             [(ngModel)]="code.circleAndBox.files[0].code"
             [codeDemoHighlight]="code.parentComponentSkeleton.match"
@@ -223,6 +227,7 @@
         <div column-5>
           <code-demo-file-path path="module.ts"></code-demo-file-path>
           <code-demo-editor
+            autoFolding
             [fontSize]="15"
             [(ngModel)]="code.circleAndBox.files[2].code"
             [codeDemoHighlight]="code.appModule.match"

--- a/apps/codelab/src/app/codelabs/angular/create-first-app/create-first-app.component.html
+++ b/apps/codelab/src/app/codelabs/angular/create-first-app/create-first-app.component.html
@@ -148,6 +148,7 @@
       class, function, property or variable
     </h2>
     <code-demo-editor
+      autoFolding
       language="typescript"
       [fontSize]="30"
       [(ngModel)]="code.decorators.code"
@@ -445,6 +446,7 @@
         <code-demo-file-path path="index.html"></code-demo-file-path>
 
         <code-demo-editor
+          autoFolding
           style="height: 50vh"
           [fontSize]="18"
           [codeDemoHighlight]="code.indexHtmlMatches['index.html']"
@@ -456,6 +458,7 @@
         <code-demo-file-path path="bootstrap.ts"></code-demo-file-path>
 
         <code-demo-editor
+          autoFolding
           style="height: 50vh"
           [fontSize]="18"
           [(ngModel)]="code.angularApp['bootstrap.ts']"
@@ -467,6 +470,7 @@
         <code-demo-file-path path="app.module.ts"></code-demo-file-path>
 
         <code-demo-editor
+          autoFolding
           style="height: 50vh"
           [fontSize]="18"
           [(ngModel)]="code.angularApp['app.module.ts']"
@@ -476,6 +480,7 @@
         <code-demo-file-path path="app.component.ts"></code-demo-file-path>
 
         <code-demo-editor
+          autoFolding
           style="height: 50vh"
           [fontSize]="18"
           [codeDemoHighlight]="code.helloMatches['app.component.ts']"

--- a/apps/codelab/src/app/codelabs/angular/create-first-app/mode/mode.component.html
+++ b/apps/codelab/src/app/codelabs/angular/create-first-app/mode/mode.component.html
@@ -8,6 +8,7 @@
       <code-demo-file-path path="app.module.ts"></code-demo-file-path>
 
       <code-demo-editor
+        autoFolding
         [fontSize]="30"
         [(ngModel)]="code.moduleAnatomy.code"
         style="height: 400px;"
@@ -27,6 +28,7 @@
   <div class="box-row">
     <div class="box-row-fill">
       <code-demo-editor
+        autoFolding
         [fontSize]="30"
         [(ngModel)]="code.moduleAnatomy.codeMobile"
         [codeDemoHighlight]="[code.moduleAnatomy.matches.importsArr]"
@@ -43,6 +45,7 @@
   <div class="box-row">
     <div class="box-row-fill">
       <code-demo-editor
+        autoFolding
         [fontSize]="30"
         [(ngModel)]="code.moduleAnatomy.codeVR"
       ></code-demo-editor>

--- a/apps/codelab/src/app/codelabs/angular/custom-events/custom-events.component.html
+++ b/apps/codelab/src/app/codelabs/angular/custom-events/custom-events.component.html
@@ -28,6 +28,7 @@
       <div column-5>
         <code-demo-file-path path="parent.ts"></code-demo-file-path>
         <code-demo-editor
+          autoFolding
           [fontSize]="15"
           [(ngModel)]="code.exercise1a.code"
           [codeDemoHighlight]="code.exercise1a.match"
@@ -40,6 +41,7 @@
       <div column-5>
         <code-demo-file-path path="child.ts"></code-demo-file-path>
         <code-demo-editor
+          autoFolding
           [fontSize]="15"
           [(ngModel)]="code.exercise1b.code"
           [codeDemoHighlight]="code.exercise1a.match"

--- a/apps/codelab/src/app/codelabs/angular/dependency-injection/dependency-injection.component.html
+++ b/apps/codelab/src/app/codelabs/angular/dependency-injection/dependency-injection.component.html
@@ -127,6 +127,7 @@
       <div class="col-6">
         <code-demo-file-path path="person.ts"></code-demo-file-path>
         <code-demo-editor
+          autoFolding
           [fontSize]="15"
           [(ngModel)]="code.withOutDI.code"
           [codeDemoHighlight]="[code.withOutDI.matches.noDI, 'profession']"
@@ -139,6 +140,7 @@
       <div class="col-6" style="margin-left: 10px;">
         <code-demo-file-path path="person-di.ts"></code-demo-file-path>
         <code-demo-editor
+          autoFolding
           [fontSize]="15"
           [(ngModel)]="code.withDI.code"
           [codeDemoHighlight]="[code.withDI.matches.constructor]"
@@ -158,6 +160,7 @@
       <div class="col-6">
         <code-demo-file-path path="person.ts"></code-demo-file-path>
         <code-demo-editor
+          autoFolding
           [fontSize]="15"
           [(ngModel)]="code.withOutDI.code2"
           [codeDemoHighlight]="[code.withOutDI.matches.noDI]"
@@ -170,6 +173,7 @@
       <div class="col-6" style="margin-left: 10px;">
         <code-demo-file-path path="person-di.ts"></code-demo-file-path>
         <code-demo-editor
+          autoFolding
           [fontSize]="15"
           [(ngModel)]="code.withDI.code"
           [codeDemoHighlight]="[code.withDI.matches.constructor]"
@@ -191,6 +195,7 @@
       <div class="col-6">
         <code-demo-file-path path="person-di.ts"></code-demo-file-path>
         <code-demo-editor
+          autoFolding
           [fontSize]="15"
           [(ngModel)]="code.withDI.code"
         ></code-demo-editor>
@@ -198,6 +203,7 @@
       <div class="col-6">
         <code-demo-file-path path="person-di.spec.ts"></code-demo-file-path>
         <code-demo-editor
+          autoFolding
           [fontSize]="15"
           [(ngModel)]="code.withDITesting.code"
         ></code-demo-editor>
@@ -229,6 +235,7 @@
     </h2>
     <code-demo-file-path path="unit-converter-service.ts"></code-demo-file-path>
     <code-demo-editor
+      autoFolding
       [(ngModel)]="code.classAsInjectable.code"
       [codeDemoHighlight]="[code.classAsInjectable.matches.injectable]"
     ></code-demo-editor>
@@ -246,6 +253,7 @@
     </h2>
     <code-demo-file-path path="app.module.ts"></code-demo-file-path>
     <code-demo-editor
+      autoFolding
       [(ngModel)]="code.provideInjectable.code"
       [codeDemoHighlight]="[
         code.provideInjectable.matches.providers,
@@ -266,6 +274,7 @@
       path="unit-conversion.component.ts"
     ></code-demo-file-path>
     <code-demo-editor
+      autoFolding
       [(ngModel)]="code.consumeInjectable.code"
       [codeDemoHighlight]="[code.consumeInjectable.matches.constructor]"
     ></code-demo-editor>

--- a/apps/codelab/src/app/codelabs/angular/pipes/pipes.component.html
+++ b/apps/codelab/src/app/codelabs/angular/pipes/pipes.component.html
@@ -83,7 +83,11 @@
   <!--  PIPES WITH ARGUMENT -->
   <div *slide id="argument-pipes" milestone="Pipes">
     <h1>Pipes with arguments:</h1>
-    <code-demo-editor [(ngModel)]="code.argumentPipes.template" language="html">
+    <code-demo-editor
+      autoFolding
+      [(ngModel)]="code.argumentPipes.template"
+      language="html"
+    >
     </code-demo-editor>
     <div class="info" milestone="Pipes">
       To add parameters to a pipe, append a colon ( : ) followed by the
@@ -94,7 +98,11 @@
   <!--  PIPES AS FILTERS  -->
   <div *slide id="pipes-as-filters" milestone="Pipes">
     <h1>Using custom pipes to filter data</h1>
-    <code-demo-editor [(ngModel)]="code.filterPipes.template" language="html">
+    <code-demo-editor
+      autoFolding
+      [(ngModel)]="code.filterPipes.template"
+      language="html"
+    >
     </code-demo-editor>
   </div>
 
@@ -102,6 +110,7 @@
   <div *slide id="crating-pipe" milestone="Pipes">
     <h1>Creating a pipe</h1>
     <code-demo-editor
+      autoFolding
       [fontSize]="25"
       [(ngModel)]="code.creatingAPipe.template"
       [codeDemoHighlight]="code.creatingAPipe.matches.exportClass"
@@ -114,6 +123,7 @@
   <div *slide id="pipeTransform" milestone="Pipes">
     <h1>Creating a pipe</h1>
     <code-demo-editor
+      autoFolding
       [fontSize]="25"
       [(ngModel)]="code.creatingAPipe.template"
       [codeDemoHighlight]="code.creatingAPipe.matches.pipeTransform"
@@ -126,6 +136,7 @@
   <div *slide id="pipe-transform-method" milestone="Pipes">
     <h1>Creating a pipe</h1>
     <code-demo-editor
+      autoFolding
       [fontSize]="25"
       [(ngModel)]="code.creatingAPipe.template"
       [codeDemoHighlight]="code.creatingAPipe.matches.method"
@@ -141,6 +152,7 @@
   <div *slide id="pipe-decorator" milestone="Pipes">
     <h1>Creating a pipe</h1>
     <code-demo-editor
+      autoFolding
       [fontSize]="25"
       [(ngModel)]="code.creatingAPipe.template"
       [codeDemoHighlight]="code.creatingAPipe.matches.decorator"

--- a/apps/codelab/src/app/codelabs/angular/structural-directives/structural-directives.component.html
+++ b/apps/codelab/src/app/codelabs/angular/structural-directives/structural-directives.component.html
@@ -110,6 +110,7 @@
     <div>
       <code-demo-file-path path="before"></code-demo-file-path>
       <code-demo-editor
+        autoFolding
         [fontSize]="fontSize"
         [minLines]="3"
         language="html"
@@ -120,6 +121,7 @@
       <br /><br />
       <code-demo-file-path path="after"></code-demo-file-path>
       <code-demo-editor
+        autoFolding
         [fontSize]="fontSize"
         [minLines]="3"
         language="html"
@@ -133,6 +135,7 @@
     <div>
       <code-demo-file-path path="before"></code-demo-file-path>
       <code-demo-editor
+        autoFolding
         [fontSize]="fontSize"
         [minLines]="3"
         language="html"
@@ -143,6 +146,7 @@
       <br /><br />
       <code-demo-file-path path="after"></code-demo-file-path>
       <code-demo-editor
+        autoFolding
         [fontSize]="fontSize"
         [minLines]="3"
         language="html"
@@ -156,6 +160,7 @@
     <div>
       <code-demo-file-path path="before"></code-demo-file-path>
       <code-demo-editor
+        autoFolding
         language="text"
         readonly="false"
         [fontSize]="fontSize"

--- a/apps/codelab/src/app/codelabs/angular/typescript/typescript/typescript.component.html
+++ b/apps/codelab/src/app/codelabs/angular/typescript/typescript/typescript.component.html
@@ -222,6 +222,7 @@
 
     <code-demo-file-path path="types.ts"></code-demo-file-path>
     <code-demo-editor
+      autoFolding
       style="height: 400px;"
       language="typescript"
       [lineNumbers]="false"
@@ -239,6 +240,7 @@
     </h2>
     <code-demo-file-path path="puppies.ts"></code-demo-file-path>
     <code-demo-editor
+      autoFolding
       style="height: 400px;"
       language="typescript"
       [lineNumbers]="false"
@@ -327,6 +329,7 @@
 
     <code-demo-file-path path="puppy.ts"></code-demo-file-path>
     <code-demo-editor
+      autoFolding
       style="height: 400px;"
       [codeDemoHighlight]="[code.classDescription.matches.exportMatch]"
       language="typescript"

--- a/libs/code-demos/src/lib/shared/monaco-config.service.ts
+++ b/libs/code-demos/src/lib/shared/monaco-config.service.ts
@@ -21,7 +21,7 @@ export const MONACO_DEFAULTS = {
   lineNumbers: false,
   automaticLayout: true,
   fontSize: 12,
-  folding: false,
+  folding: true,
   minimap: {
     enabled: false
   }


### PR DESCRIPTION
The original reported issue is that HTML is auto-folded.
But as of this PR, the observed behavior is that nothing
is auto-folded.

Changes:
- configure Monaco setting to `folding: true` - fixes all
  use cases of <code-demo-multitab-editor>
- add `autoFold` directive to <code-demo-editor> uses